### PR TITLE
document.registerElement is deprecated

### DIFF
--- a/scripts/main.es6_FINAL.js
+++ b/scripts/main.es6_FINAL.js
@@ -145,4 +145,4 @@ StickyNote.TEMPLATE = `
 StickyNote.CLASSES = ['mdl-cell--4-col-desktop', 'mdl-card__supporting-text', 'mdl-cell--12-col',
   'mdl-shadow--2dp', 'mdl-cell--4-col-tablet', 'mdl-card', 'mdl-cell', 'sticky-note'];
 
-document.registerElement('sticky-note', StickyNote);
+customElements.define('sticky-note', StickyNote);


### PR DESCRIPTION
According with [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Document/registerElement) `document.registerElement` is deprecated in favor of [customElements.define()](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define)