### PR TITLE
createdCallback deprecated

### DIFF
--- a/scripts/main.es6_FINAL.js
+++ b/scripts/main.es6_FINAL.js
@@ -91,7 +91,7 @@ window.addEventListener('load', () => new StickyNotesApp());
 class StickyNote extends HTMLElement {
 
   // Fires when an instance of the element is created.
-  createdCallback() {
+  connectedCallback () {
     this.classList.add(...StickyNote.CLASSES);
     this.innerHTML = StickyNote.TEMPLATE;
     this.messageElement = this.querySelector('.message');


### PR DESCRIPTION
Did not find 'createdCallback' on MDN documentation, probably it is deprecated.
Replaced with connectedCallback and its working fine.